### PR TITLE
Add global repaint method and make getElementData private

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -78,6 +78,10 @@
             });
 
             return data;
+        },
+
+        repaint: function ($elem) {
+            $elem.attr('class', $elem.attr('class'));
         }
     };
 }));


### PR DESCRIPTION
#### Refactor
- getElementData() is used only inside core and is therefore private from now on
#### Added
- repaint() was added to asimov.core to provide a global repaint method to fix issues with old Internet Explorer versions (8) and some native Android browser
- Setting the existing classname(s) to the element itself seem to be the only reliable approach which works across the affected browsers
