### PR TITLE
fix(get): edge case with resolving aliases to maps

### DIFF
--- a/core.scss
+++ b/core.scss
@@ -167,23 +167,35 @@ $__a__map-cache: () !default;
 // -----------------------------------------------------------------------------
 // @return [Literal]
 @function get($key, $_root:null) {
+    $is-root: true;
+
     // $_root won't exist the first time around, default it to $settings
     @if $_root == null {
         $_root: $settings;
     }
 
-    @while (str-index($key, "/") or 0) > 0 {
+    $break: false; // Emulate break statements
+    @while (str-index($key, "/") or 0) > 0 and $break == false {
         $child-key: str-slice($key, 1, str-index($key, "/") - 1);
         $key: str-slice($key, str-index($key, "/") + 1);
-        $_root: map-get($_root, $child-key) or ();
+        @if type-of(map-get($_root, $child-key)) == map {
+        $_root: map-get($_root, $child-key);
+        $is-root: false;
+        } @else {
+            $break: true;
+        }
     }
 
-    $value: map-get($_root, $key);
+    $value: if(type-of($_root) == map, map-get($_root, $key), $_root);
 
     @if is-lazy($value) {
         @return exec-lazy($value);
     } @else if type-of($value) == map {
-        @return resolve-aliases($value, $settings);
+        @return resolve-aliases($value, $settings, $is-root);
+    } @else if looks-like-an-alias($value) {
+        @debug("$value looks-like-an-alias");
+        @debug("calling resolve-aliases");
+        @return get($value);
     } @else {
         @return resolve-alias($value);
     };
@@ -307,7 +319,7 @@ $__a__map-cache: () !default;
             $ret: append($ret, resolve-alias($item));
         }
 
-        @return $ret;
+        @return if(length($ret) > 0, $ret, null);
     }
 
     $value: $name;
@@ -340,12 +352,13 @@ $__a__map-cache: () !default;
 // @param $extras [Map] : an external map to resolve aliases against
 // -----------------------------------------------------------------------------
 // @return [Map]
-@function resolve-aliases($map, $extras:()) {
+@function resolve-aliases($map, $extras:(), $is-root:true) {
     $ret: ();
     @each $name, $value in $map {
         // Looks like an alias, try to resolve it, default to $value
         @if type-of($value) == string {
-            $value: lookup($ret, $value, lookup($extras, $value, $value));
+            $default: lookup($extras, $value, $value);
+            $value: if($is-root, lookup($ret, $value, $default), $default);
             $ret: map-merge($ret, ($name: $value));
         } @else
         // Recursion yo!

--- a/tests/scss/_core.scss
+++ b/tests/scss/_core.scss
@@ -84,6 +84,41 @@ $before: ((
             @include should(expect(get("this/is/not/an/alias")), to(be-null()));
         }
 
+        @include describe("to a map") {
+
+            @include it("should return the aliased map") {
+                $map: ( foo: "bar", bar: "baz", baz: "baz" );
+                $map1: ( foo: "bar", bar: "baz", baz: "inie/minie" );
+                $map2: ( baz: "foo/bar", foo: "bar", bar: "baz" );
+                $map3: ( foo: "bar", bar: "baz", baz: "foo/bar" );
+
+                $settings: set((
+                    foo: ( bar: "baz" ),
+                    inie: ( minie: "baz" ),
+                    this: ( is: ( an: ( alias: "i/am/a/map" ))),
+                )) !global;
+
+                @include should(expect(get("foo/bar")), to(be("baz")));
+
+                $settings: set((i: (am: ( a: ( map: $map ))))) !global;
+                @include should(expect(get("i/am/a/map")), to(be($map)));
+                @include should(expect(get("this/is/an/alias")), to(be($map)));
+
+                $settings: set((i: (am: ( a: ( map: $map1 ))))) !global;
+                @include should(expect(get("i/am/a/map")), to(be($map)));
+                @include should(expect(get("this/is/an/alias")), to(be($map)));
+
+                $settings: set((i: (am: ( a: ( map: $map2 ))))) !global;
+                @include should(expect(get("i/am/a/map")), to(be($map)));
+                @include should(expect(get("this/is/an/alias")), to(be($map)));
+
+                $settings: set((i: (am: ( a: ( map: $map3 ))))) !global;
+                @include should(expect(get("i/am/a/map")), to(be($map)));
+                @include should(expect(get("this/is/an/alias")), to(be($map)));
+            }
+
+        }
+
     }
 
 }
@@ -333,14 +368,6 @@ $before: ((
             $default: "default";
 
             @include should(expect(lookup($map, baz, $default:$default)), to(be($default)));
-        }
-
-        @include it("should return a custom default lookup") {
-            $map: (foo: bar, bar: baz);
-            $default: "bar";
-            $ret: "baz";
-
-            @include should(expect(lookup($map, baz, $default:$default, $is-key:true)), to(be($ret)));
         }
 
     }


### PR DESCRIPTION
This PR fixes an edge case where `get` an alias to a map incorrectly resolves the alias to the map, or some aliases within that map itself.

Fixes #23.
