### PR TITLE
test(get): eval lazy in map that is aliased

### DIFF
--- a/tests/scss/_core.scss
+++ b/tests/scss/_core.scss
@@ -132,6 +132,22 @@ $before: ((
 
         }
 
+        @include describe("to a map with a lazy") {
+
+            @include it("should evaluate the lazy") {
+                $map: ( lazy: "winning bar", not-lazy: "normal value" );
+                $settings: set((
+                    foo: ( bar: ( lazy: lazy("foofoofoofoo"), not-lazy: "normal value" )),
+                    this: ( is: ( an: ( alias: "foo/bar" ))),
+                )) !global;
+
+                @debug(get("this/is/an/alias"));
+
+                @include should(expect(get("this/is/an/alias")), to(be($map)));
+            }
+
+        }
+
     }
 
 }


### PR DESCRIPTION
This PR make sure lazies in maps that are aliased are evaluated as expect.

``` sass
@function hello($name:"world") {
    @return "hello " + $name;
}

// ------------

$settings: set((
    foo: ( bar: ( lazy: lazy("hello"), not-lazy: "normal value" )),
    this: ( is: ( an: ( alias: "foo/bar" ))),
)) !global;

// ------------

@debug(get("this/is/an/alias")); 

```

**Expected** `( lazy: "hello world", not-lazy: "normal value" )`

**Actual** `hello world`

Fixes #15.
