### PR TITLE
fix(get): should preserve original separator for list values

### DIFF
--- a/core.scss
+++ b/core.scss
@@ -304,7 +304,7 @@ $__a__map-cache: () !default;
         $ret:();
 
         @each $item in $name {
-            $ret: append($ret, resolve-alias($item));
+            $ret: append($ret, resolve-alias($item), list-separator($name));
         }
 
         @return $ret;


### PR DESCRIPTION
Currently when `get` returns a list value it coerces the separator
to a space. This breaks the CSS for things like multiple backgrounds
and multiple box-shadows.

/cc @andrewk 