### PR TITLE
Add test for preserving list separator

### DIFF
--- a/tests/scss/_core.scss
+++ b/tests/scss/_core.scss
@@ -335,14 +335,6 @@ $before: ((
             @include should(expect(lookup($map, baz, $default:$default)), to(be($default)));
         }
 
-        @include it("should return a custom default lookup") {
-            $map: (foo: bar, bar: baz);
-            $default: "bar";
-            $ret: "baz";
-
-            @include should(expect(lookup($map, baz, $default:$default, $is-key:true)), to(be($ret)));
-        }
-
     }
 
 }

--- a/tests/scss/_core.scss
+++ b/tests/scss/_core.scss
@@ -9,6 +9,7 @@
 // -----------------------------------------------------------------------------
 
 $before: ((
+    list: (foo, bar, baz),
     foo: (
         bar: (
             bat: "woop",
@@ -64,6 +65,12 @@ $before: ((
             $settings: set($before) !global;
 
             @include should(expect(get("foo/bar/baz")), to(be-null()));
+        }
+
+        @include it("should preserve list separators") {
+            $settings: set($before) !global;
+
+            @include should(expect(list-separator(get("list"))), to(be(comma)));
         }
 
     }
@@ -140,6 +147,7 @@ $before: ((
             $settings: $before !global;
 
             $map: ((
+                list: (foo, bar, baz),
                 hello: "john",
                 my: ( name: ( is: "bob" ) ),
                 this: ( is: "me" ),
@@ -147,6 +155,7 @@ $before: ((
             $settings: set($map) !global;
 
             $ret: ((
+                list: (foo, bar, baz),
                 hello: "john",
                 my: ( name: ( is: "bob" ) ),
                 this: ( is: "me" ),
@@ -221,6 +230,7 @@ $before: ((
             $settings: $before !global;
 
             $map: ((
+                list: (foo, bar, baz),
                 hello: "john",
                 my: ( name: ( is: "bob" ) ),
                 this: ( is: "me" ),
@@ -228,6 +238,7 @@ $before: ((
             $settings: set-default($map) !global;
 
             $ret: ((
+                list: (foo, bar, baz),
                 hello: "john",
                 my: ( name: ( is: "bob" ) ),
                 foo: (


### PR DESCRIPTION
This PR add test for test for preserving list separator (#31).
It also updates some test that are failing due to recent refactors.