### PR TITLE
feat(responsive-property): add an `$important` flag

### DIFF
--- a/_mixin.scss
+++ b/_mixin.scss
@@ -1,18 +1,18 @@
 
-@mixin responsive-property($key, $property) {
+@mixin responsive-property($key, $property, $important: false) {
     $map: get($key);
 
     @if type-of($map) != map {
-        #{$property}: $map;
+        #{$property}: $map #{if($important, "!important", "")};
     } @else {
         @each $bp, $value in $map {
             $value: if(is-lazy($value), exec-lazy($value), $value);
 
             @if $bp == "all" {
-                #{$property}: $value;
+                #{$property}: $value #{if($important, "!important", "")};
             } @else {
                 @include breakpoint(get("breakpoint/#{$bp}")) {
-                    #{$property}: $value;
+                    #{$property}: $value #{if($important, "!important", "")};
                 }
             }
         }


### PR DESCRIPTION
This PR adds an `$important` flag to the `responsive-property`
mixin for when a property needs to be `!important`.

``` sass
$settings: ( "foo" : ( "all": "green" ));

.component {
  @include responsive-property("foo", "color");
}
.component-important {
  @include responsive-property("foo", "color", true);
}
```

``` css
.component {
  color: green;
}
.component-important {
  color: green !important;
}
```
